### PR TITLE
validazión agarrar

### DIFF
--- a/src/auto.wlk
+++ b/src/auto.wlk
@@ -21,8 +21,20 @@ object auto{
 
 
     method agarrarObjeto() {
+      self.validarAgarrar()
       const objeto = game.uniqueCollider(self)
       objeto.objetoALaBarra()
     }
+    method validarAgarrar(){
+      if(not self.hayObjeto()){
+        self.error("") 
+      }  
+    }
 
+    method hayObjeto(){
+      return game.colliders(self).size() > 0
+    }
+
+
+    
 }


### PR DESCRIPTION
cree la validación al momento de agarrar, para que no salte un error en caso de apretar "a" en una posición en la que no hay un objeto q agarrar